### PR TITLE
adding updated code projects for CDC

### DIFF
--- a/code.json
+++ b/code.json
@@ -3982,1908 +3982,2052 @@
           "name": "U.S. Department of Health & Human Services"
         }
       },
-        {
-            "contact": {
-                "URL": "https://github.com/informaticslab",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2016-08-24",
-                "lastModified": "2016-08-24"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/informaticslab/zika-pregnancy-testing/downloads",
-            "homepageURL": "https://github.com/informaticslab/zika-pregnancy-testing",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "HTML",
-                "CSS"
-            ],
-            "name": "zika-pregnancy-testing",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": null,
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/informaticslab/zika-pregnancy-testing.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+      {
+        "contact": {
+            "URL": "https://github.com/informaticslab",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/informaticslab",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2016-06-13",
-                "lastModified": "2016-12-15"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/informaticslab/zika-risk-assessment/downloads",
-            "homepageURL": "https://github.com/informaticslab/zika-risk-assessment",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "JavaScript",
-                "CSS"
-            ],
-            "name": "zika-risk-assessment",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": null,
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/informaticslab/zika-risk-assessment.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2016-08-24",
+            "lastModified": "2016-08-24"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/informaticslab",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2012-11-29",
-                "lastModified": "2016-11-08"
-            },
-            "description": "PTT Advisor iOS app to provide clinical decision support for prolonged partial thromboplastin time (PTT).",
-            "downloadURL": "https://api.github.com/repos/informaticslab/ptt-advisor/downloads",
-            "homepageURL": "https://github.com/informaticslab/ptt-advisor",
-            "laborHours": 0,
-            "languages": [
-                "Objective-C",
-                "HTML"
-            ],
-            "name": "ptt-advisor",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": null,
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/informaticslab/ptt-advisor.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/informaticslab/zika-pregnancy-testing/downloads",
+        "homepageURL": "https://github.com/informaticslab/zika-pregnancy-testing",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "HTML",
+            "CSS"
+        ],
+        "name": "zika-pregnancy-testing",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/Epi-Info",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-30",
-                "lastModified": "2018-11-19"
-            },
-            "description": "REST API to interface with Epi Info web platform and Epi Info 7",
-            "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Survey-API/downloads",
-            "homepageURL": "https://github.com/Epi-Info/Epi-Info-Survey-API",
-            "laborHours": 0,
-            "languages": [
-                "C#",
-                "JavaScript",
-                "HTML",
-                "CSS",
-                "ASP"
-            ],
-            "name": "Epi-Info-Survey-API",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": null,
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Survey-API.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/informaticslab/zika-pregnancy-testing.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/informaticslab",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/Epi-Info",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-11-30",
-                "lastModified": "2018-06-12"
-            },
-            "description": "Epi Info™ Companion for Android",
-            "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Android/downloads",
-            "homepageURL": "https://github.com/Epi-Info/Epi-Info-Android",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML"
-            ],
-            "name": "Epi-Info-Android",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Android.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2016-06-13",
+            "lastModified": "2016-12-15"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/Epi-Info",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-11-20",
-                "lastModified": "2019-06-12"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Web-Survey/downloads",
-            "homepageURL": "https://github.com/Epi-Info/Epi-Info-Web-Survey",
-            "laborHours": 0,
-            "languages": [
-                "C#",
-                "JavaScript",
-                "CSS",
-                "HTML",
-                "PowerShell",
-                "ASP"
-            ],
-            "name": "Epi-Info-Web-Survey",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": null,
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Web-Survey.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/informaticslab/zika-risk-assessment/downloads",
+        "homepageURL": "https://github.com/informaticslab/zika-risk-assessment",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "JavaScript",
+            "CSS"
+        ],
+        "name": "zika-risk-assessment",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/Epi-Info",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-09-14",
-                "lastModified": "2019-06-12"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Community-Edition/downloads",
-            "homepageURL": "https://github.com/Epi-Info/Epi-Info-Community-Edition",
-            "laborHours": 0,
-            "languages": [
-                "C#",
-                "Visual Basic",
-                "HTML",
-                "Rich Text Format",
-                "Roff",
-                "ASP",
-                "TSQL",
-                "Batchfile"
-            ],
-            "name": "Epi-Info-Community-Edition",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Community-Edition.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/informaticslab/zika-risk-assessment.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/informaticslab",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/Epi-Info",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-08-21",
-                "lastModified": "2017-08-21"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Cloud-Data-Capture/downloads",
-            "homepageURL": "https://github.com/Epi-Info/Epi-Info-Cloud-Data-Capture",
-            "laborHours": 0,
-            "languages": [
-                "C#",
-                "JavaScript",
-                "CSS",
-                "ASP",
-                "HTML"
-            ],
-            "name": "Epi-Info-Cloud-Data-Capture",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Cloud-Data-Capture.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2012-11-29",
+            "lastModified": "2016-11-08"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/Epi-Info",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2016-04-11",
-                "lastModified": "2018-08-13"
-            },
-            "description": "Epi Info's scalable Cloud Contact Tracing platform build using .NET framework and Azure PaaS services ",
-            "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Cloud-Contact-Tracing/downloads",
-            "homepageURL": "https://github.com/Epi-Info/Epi-Info-Cloud-Contact-Tracing",
-            "laborHours": 0,
-            "languages": [
-                "C#",
-                "JavaScript",
-                "CSS",
-                "PLpgSQL",
-                "PowerShell",
-                "ASP",
-                "HTML",
-                "Roff"
-            ],
-            "name": "Epi-Info-Cloud-Contact-Tracing",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Cloud-Contact-Tracing.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "description": "PTT Advisor iOS app to provide clinical decision support for prolonged partial thromboplastin time (PTT).",
+        "downloadURL": "https://api.github.com/repos/informaticslab/ptt-advisor/downloads",
+        "homepageURL": "https://github.com/informaticslab/ptt-advisor",
+        "laborHours": 0,
+        "languages": [
+            "Objective-C",
+            "HTML"
+        ],
+        "name": "ptt-advisor",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/Epi-Info",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2016-01-22",
-                "lastModified": "2018-12-19"
-            },
-            "description": "Epi Info™ Companion for iOS",
-            "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-iOS/downloads",
-            "homepageURL": "https://github.com/Epi-Info/Epi-Info-iOS",
-            "laborHours": 0,
-            "languages": [
-                "Objective-C",
-                "Swift",
-                "C++",
-                "C",
-                "HTML"
-            ],
-            "name": "Epi-Info-iOS",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/Epi-Info/Epi-Info-iOS.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/informaticslab/ptt-advisor.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/Epi-Info",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2019-04-23",
-                "lastModified": "2019-04-30"
-            },
-            "description": "A little web tool to help people translate CSVs to FASTA and vice-versa.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/CSV2FASTA/downloads",
-            "homepageURL": "https://github.com/CDCgov/CSV2FASTA",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "CSS"
-            ],
-            "name": "CSV2FASTA",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/CSV2FASTA.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2018-04-30",
+            "lastModified": "2018-11-19"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2019-04-17",
-                "lastModified": "2019-04-17"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/CDCgov/Ocra/downloads",
-            "homepageURL": "https://github.com/CDCgov/Ocra",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "HTML",
-                "CSS"
-            ],
-            "name": "Ocra",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/Ocra.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "description": "REST API to interface with Epi Info web platform and Epi Info 7",
+        "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Survey-API/downloads",
+        "homepageURL": "https://github.com/Epi-Info/Epi-Info-Survey-API",
+        "laborHours": 0,
+        "languages": [
+            "C#",
+            "JavaScript",
+            "HTML",
+            "CSS",
+            "ASP"
+        ],
+        "name": "Epi-Info-Survey-API",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2019-03-19",
-                "lastModified": "2019-06-06"
-            },
-            "description": "GeneFlow: A Workflow Engine for Bioinformatics and Public Health Analytics",
-            "downloadURL": "https://api.github.com/repos/CDCgov/geneflow/downloads",
-            "homepageURL": "https://github.com/CDCgov/geneflow",
-            "laborHours": 0,
-            "languages": [
-                "Python",
-                "Shell",
-                "Gherkin",
-                "Dockerfile"
-            ],
-            "name": "geneflow",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/geneflow.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Survey-API.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/Epi-Info",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2019-03-18",
-                "lastModified": "2019-05-15"
-            },
-            "description": "A little R package to Launch MicrobeTrace in a Shiny Server",
-            "downloadURL": "https://api.github.com/repos/CDCgov/MicrobeTraceShiny/downloads",
-            "homepageURL": "https://github.com/CDCgov/MicrobeTraceShiny",
-            "laborHours": 0,
-            "languages": [
-                "R"
-            ],
-            "name": "MicrobeTraceShiny",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/MicrobeTraceShiny.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2017-11-30",
+            "lastModified": "2018-06-12"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2019-03-07",
-                "lastModified": "2019-03-08"
-            },
-            "description": "Ruby Source-to-Image builder tailored to the needs of the SDP Vocabulary project.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/s2i-ruby-vocab-builder/downloads",
-            "homepageURL": "https://github.com/CDCgov/s2i-ruby-vocab-builder",
-            "laborHours": 0,
-            "languages": [
-                "Shell",
-                "Roff",
-                "Dockerfile",
-                "Makefile",
-                "Ruby"
+        "description": "Epi Info™ Companion for Android",
+        "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Android/downloads",
+        "homepageURL": "https://github.com/Epi-Info/Epi-Info-Android",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML"
+        ],
+        "name": "Epi-Info-Android",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "s2i-ruby-vocab-builder",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/s2i-ruby-vocab-builder.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2019-02-11",
-                "lastModified": "2019-02-11"
-            },
-            "description": "A Simple Demonstration of Organizing Bubbles using D3v5",
-            "downloadURL": "https://api.github.com/repos/CDCgov/Bubbles/downloads",
-            "homepageURL": "https://github.com/CDCgov/Bubbles",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "CSS",
-                "R"
-            ],
-            "name": "Bubbles",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "name": "NOASSERTION"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/Bubbles.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Android.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/Epi-Info",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2019-01-14",
-                "lastModified": "2019-05-20"
-            },
-            "description": "Yet Another D3-powered Phylogenetic Tree Library",
-            "downloadURL": "https://api.github.com/repos/CDCgov/TidyTree/downloads",
-            "homepageURL": "https://github.com/CDCgov/TidyTree",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript"
-            ],
-            "name": "TidyTree",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/TidyTree.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2017-11-20",
+            "lastModified": "2019-10-10"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2019-01-03",
-                "lastModified": "2019-04-22"
-            },
-            "description": "Spawn Normally-Distributed Mutant DNA Sequences",
-            "downloadURL": "https://api.github.com/repos/CDCgov/SeqSpawnR/downloads",
-            "homepageURL": "https://github.com/CDCgov/SeqSpawnR",
-            "laborHours": 0,
-            "languages": [
-                "R"
-            ],
-            "name": "SeqSpawnR",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/SeqSpawnR.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Web-Survey/downloads",
+        "homepageURL": "https://github.com/Epi-Info/Epi-Info-Web-Survey",
+        "laborHours": 0,
+        "languages": [
+            "C#",
+            "JavaScript",
+            "CSS",
+            "HTML",
+            "PowerShell",
+            "ASP"
+        ],
+        "name": "Epi-Info-Web-Survey",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-12-14",
-                "lastModified": "2019-05-10"
-            },
-            "description": "A little library to work with Javascript File objects",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fileto/downloads",
-            "homepageURL": "https://github.com/CDCgov/fileto",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript"
-            ],
-            "name": "fileto",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fileto.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Web-Survey.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/Epi-Info",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-12-07",
-                "lastModified": "2019-01-03"
-            },
-            "description": "A stubbing service for testing against the various endpoints of the FDNS Microservices without running the full microservices in the background.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-stubbing/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-stubbing",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "Makefile",
-                "Dockerfile"
-            ],
-            "name": "fdns-ms-stubbing",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-stubbing.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2017-09-14",
+            "lastModified": "2019-11-18"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-12-04",
-                "lastModified": "2019-05-10"
-            },
-            "description": "A Phylogenetics toolkit for Javascript",
-            "downloadURL": "https://api.github.com/repos/CDCgov/patristic/downloads",
-            "homepageURL": "https://github.com/CDCgov/patristic",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "JavaScript",
-                "CSS",
-                "TeX"
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Community-Edition/downloads",
+        "homepageURL": "https://github.com/Epi-Info/Epi-Info-Community-Edition",
+        "laborHours": 0,
+        "languages": [
+            "C#",
+            "Visual Basic",
+            "HTML",
+            "Rich Text Format",
+            "Roff",
+            "ASP",
+            "TSQL",
+            "Batchfile"
+        ],
+        "name": "Epi-Info-Community-Edition",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "patristic",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/patristic.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-10-31",
-                "lastModified": "2018-11-13"
-            },
-            "description": "Example UI for an HL7 Combiner Tool",
-            "downloadURL": "https://api.github.com/repos/CDCgov/ex-ui-hl7-combiner/downloads",
-            "homepageURL": "https://github.com/CDCgov/ex-ui-hl7-combiner",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "HTML",
-                "CSS",
-                "Dockerfile",
-                "Makefile",
-                "Shell"
-            ],
-            "name": "ex-ui-hl7-combiner",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/ex-ui-hl7-combiner.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Community-Edition.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/Epi-Info",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-09-21",
-                "lastModified": "2019-06-12"
-            },
-            "description": "The Visualization Multitool for Molecular Epidemiology and Bioinformatics",
-            "downloadURL": "https://api.github.com/repos/CDCgov/MicrobeTrace/downloads",
-            "homepageURL": "https://github.com/CDCgov/MicrobeTrace",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "JavaScript",
-                "CSS",
-                "Shell",
-                "Dockerfile"
-            ],
-            "name": "MicrobeTrace",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/MicrobeTrace.git",
-            "status": "Development",
-            "tags": [
-                "github",
-                "bioinformatics",
-                "epidemiology",
-                "network-visualization",
-                "hiv",
-                "cdc",
-                "pathogens",
-                "phylogenetics",
-                "phylogenetic-trees",
-                "phylogeny",
-                "phylogenomics",
-                "genomics",
-                "genomics-visualization",
-                "genomic-data-analysis",
-                "sequence-alignment"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2017-08-21",
+            "lastModified": "2019-10-09"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-09-06",
-                "lastModified": "2018-12-27"
-            },
-            "description": "This is the repository with the Java Library for Foundation Services Kafka workers.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-kafka-library/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-kafka-library",
-            "laborHours": 0,
-            "languages": [
-                "Java"
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Cloud-Data-Capture/downloads",
+        "homepageURL": "https://github.com/Epi-Info/Epi-Info-Cloud-Data-Capture",
+        "laborHours": 0,
+        "languages": [
+            "C#",
+            "JavaScript",
+            "CSS",
+            "HTML",
+            "TSQL",
+            "ASP"
+        ],
+        "name": "Epi-Info-Cloud-Data-Capture",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "fdns-kafka-library",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-kafka-library.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-08-09",
-                "lastModified": "2018-12-27"
-            },
-            "description": "This is the repository for the cryptography microservice.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-crypto/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-crypto",
-            "laborHours": 0,
-            "languages": [],
-            "name": "fdns-ms-crypto",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": null,
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-crypto.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Cloud-Data-Capture.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/Epi-Info",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-08-09",
-                "lastModified": "2018-12-27"
-            },
-            "description": "This is the repository that contains the Kafka workers to handle the generation of reports.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-reporting-kafka/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-reporting-kafka",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "Makefile",
-                "Dockerfile",
-                "Shell"
-            ],
-            "name": "fdns-ms-reporting-kafka",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-reporting-kafka.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2016-04-11",
+            "lastModified": "2018-08-13"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-08-09",
-                "lastModified": "2019-02-07"
-            },
-            "description": "This is the repository for the reporting microservice.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-reporting/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-reporting",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML",
-                "Makefile",
-                "Dockerfile"
+        "description": "Epi Info's scalable Cloud Contact Tracing platform build using .NET framework and Azure PaaS services ",
+        "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-Cloud-Contact-Tracing/downloads",
+        "homepageURL": "https://github.com/Epi-Info/Epi-Info-Cloud-Contact-Tracing",
+        "laborHours": 0,
+        "languages": [
+            "C#",
+            "JavaScript",
+            "CSS",
+            "PLpgSQL",
+            "PowerShell",
+            "ASP",
+            "HTML",
+            "Roff"
+        ],
+        "name": "Epi-Info-Cloud-Contact-Tracing",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "fdns-ms-reporting",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-reporting.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-08-09",
-                "lastModified": "2019-02-07"
-            },
-            "description": "This is the repository with the Microsoft Utilities microservice for parsing Microsoft formatted documents.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-msft-utils/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-msft-utils",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML",
-                "Dockerfile",
-                "Makefile"
-            ],
-            "name": "fdns-ms-msft-utils",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-msft-utils.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/Epi-Info/Epi-Info-Cloud-Contact-Tracing.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/Epi-Info",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-06",
-                "lastModified": "2018-08-23"
-            },
-            "description": "This is the repository extending the Springfox Swagger UI package to meet CDC browser requirements.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/springfox-swagger-ui/downloads",
-            "homepageURL": "https://github.com/CDCgov/springfox-swagger-ui",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "JavaScript",
-                "CSS"
-            ],
-            "name": "springfox-swagger-ui",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/springfox-swagger-ui.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2016-01-22",
+            "lastModified": "2019-11-18"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-02-07"
-            },
-            "description": "This is the repository with the Business Rules Engine for ingesting and validating JSON files.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-rules/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-rules",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML",
-                "Dockerfile",
-                "Makefile"
+        "description": "Epi Info™ Companion for iOS",
+        "downloadURL": "https://api.github.com/repos/Epi-Info/Epi-Info-iOS/downloads",
+        "homepageURL": "https://github.com/Epi-Info/Epi-Info-iOS",
+        "laborHours": 0,
+        "languages": [
+            "Objective-C",
+            "Swift",
+            "C++",
+            "C",
+            "HTML"
+        ],
+        "name": "Epi-Info-iOS",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "fdns-ms-rules",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-rules.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-02-13"
-            },
-            "description": "This is the repository with the Combiner service to combine JSON files into a single CSV or XLSX file.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-combiner/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-combiner",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML",
-                "Dockerfile",
-                "Makefile",
-                "Shell"
-            ],
-            "name": "fdns-ms-combiner",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-combiner.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/Epi-Info/Epi-Info-iOS.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-02-07"
-            },
-            "description": "This is the repository with the CDA utilities service to parse, validate and generate sample CDA data.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-cda-utils/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-cda-utils",
-            "laborHours": 0,
-            "languages": [
-                "FreeMarker",
-                "Java",
-                "HTML",
-                "Dockerfile",
-                "Makefile"
-            ],
-            "name": "fdns-ms-cda-utils",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-cda-utils.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2019-07-29",
+            "lastModified": "2019-08-07"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-03-29"
-            },
-            "description": "This is the repository with the HL7 utilities service to parse, validate and generate sample HL7 data.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-hl7-utils/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-hl7-utils",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML",
-                "FreeMarker",
-                "Dockerfile",
-                "Makefile"
+        "description": "A little web tool to help people join data tables (without writing code!)",
+        "downloadURL": "https://api.github.com/repos/CDCgov/TableMerger/downloads",
+        "homepageURL": "https://github.com/CDCgov/TableMerger",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "CSS"
+        ],
+        "name": "TableMerger",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "fdns-ms-hl7-utils",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-hl7-utils.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-02-07"
-            },
-            "description": "This is the repository with the Indexing layer for the Data Lake. This is the navigation layer.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-indexing/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-indexing",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML",
-                "Dockerfile",
-                "Makefile"
-            ],
-            "name": "fdns-ms-indexing",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-indexing.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/CDCgov/TableMerger.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-02-07"
-            },
-            "description": "This is the repository with the Object layer for the Data Lake. This is the mutable layer.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-object/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-object",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML",
-                "Dockerfile",
-                "Makefile"
-            ],
-            "name": "fdns-ms-object",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-object.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2019-07-17",
+            "lastModified": "2019-07-29"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-02-07"
-            },
-            "description": "This is the repository with the Storage layer for the Data Lake. This is the immutable layer.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-storage/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-storage",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "HTML",
-                "Dockerfile",
-                "Makefile"
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/CDCgov/Mia_publication/downloads",
+        "homepageURL": "https://github.com/CDCgov/Mia_publication",
+        "laborHours": 0,
+        "languages": [
+            "TSQL",
+            "R",
+            "Shell",
+            "Python"
+        ],
+        "name": "Mia_publication",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "fdns-ms-storage",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-storage.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-02-07"
-            },
-            "description": "This is the repository with the API gateway to connect the other microservices together.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-gateway/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ms-gateway",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "Java",
-                "Dockerfile",
-                "Shell",
-                "Makefile"
-            ],
-            "name": "fdns-ms-gateway",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ms-gateway.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/CDCgov/Mia_publication.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2018-12-27"
-            },
-            "description": "This the repository with the Java Library for the Business Rules Engine.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-rules-engine/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-rules-engine",
-            "laborHours": 0,
-            "languages": [
-                "Java"
-            ],
-            "name": "fdns-rules-engine",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-rules-engine.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2019-06-07",
+            "lastModified": "2019-06-07"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-02-13"
-            },
-            "description": "This is the repository with the Java SDK for Foundation Services.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-java-sdk/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-java-sdk",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "Makefile"
-            ],
-            "name": "fdns-java-sdk",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-java-sdk.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "description": "Project for HL7 Dev Days 2019 Redmond. Converts V2 PIDs to FHIR Patient Resources",
+        "downloadURL": "https://api.github.com/repos/CDCgov/pid2fhir/downloads",
+        "homepageURL": "https://github.com/CDCgov/pid2fhir",
+        "laborHours": 0,
+        "languages": [
+            "Kotlin"
+        ],
+        "name": "pid2fhir",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2018-10-30"
-            },
-            "description": "This is the repository with the JavaScript SDK for Foundation Services.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-js-sdk/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-js-sdk",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript"
-            ],
-            "name": "fdns-js-sdk",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-js-sdk.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/CDCgov/pid2fhir.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-04-03",
-                "lastModified": "2019-06-08"
-            },
-            "description": "This is the repository with the front-end library built in React.",
-            "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ui-react/downloads",
-            "homepageURL": "https://github.com/CDCgov/fdns-ui-react",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "CSS"
-            ],
-            "name": "fdns-ui-react",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/fdns-ui-react.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2019-05-24",
+            "lastModified": "2019-05-24"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-03-19",
-                "lastModified": "2019-05-15"
-            },
-            "description": "Pick a county, see its neighbors",
-            "downloadURL": "https://api.github.com/repos/CDCgov/Proximate/downloads",
-            "homepageURL": "https://github.com/CDCgov/Proximate",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "HTML",
-                "CSS"
+        "description": "Run Shiny. Make Gantt Charts.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/ShinyGanttCharts/downloads",
+        "homepageURL": "https://github.com/CDCgov/ShinyGanttCharts",
+        "laborHours": 0,
+        "languages": [
+            "R"
+        ],
+        "name": "ShinyGanttCharts",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "Proximate",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": null,
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/Proximate.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-02-07",
-                "lastModified": "2019-05-02"
-            },
-            "description": "Tamura-Nei '93 Computation in Javascript",
-            "downloadURL": "https://api.github.com/repos/CDCgov/tn93.js/downloads",
-            "homepageURL": "https://github.com/CDCgov/tn93.js",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "HTML",
-                "CSS"
-            ],
-            "name": "tn93.js",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/tn93.js.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/CDCgov/ShinyGanttCharts.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2018-02-07",
-                "lastModified": "2019-05-02"
-            },
-            "description": "A lightweight visualization for genetic sequence alignments",
-            "downloadURL": "https://api.github.com/repos/CDCgov/AlignmentViewer/downloads",
-            "homepageURL": "https://github.com/CDCgov/AlignmentViewer",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "HTML"
-            ],
-            "name": "AlignmentViewer",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/AlignmentViewer.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2019-04-23",
+            "lastModified": "2019-04-30"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-12-25",
-                "lastModified": "2019-01-18"
-            },
-            "description": "An application to assist Utah CDC's Newborn Screening Program",
-            "downloadURL": "https://api.github.com/repos/CDCgov/artemis/downloads",
-            "homepageURL": "https://github.com/CDCgov/artemis",
-            "laborHours": 0,
-            "languages": [
-                "Ruby",
-                "HTML",
-                "CSS",
-                "JavaScript",
-                "Dockerfile"
+        "description": "A little web tool to help people translate CSVs to FASTA and vice-versa.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/CSV2FASTA/downloads",
+        "homepageURL": "https://github.com/CDCgov/CSV2FASTA",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "CSS"
+        ],
+        "name": "CSV2FASTA",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "artemis",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "name": "NOASSERTION"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/artemis.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-12-06",
-                "lastModified": "2019-06-10"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/CDCgov/MaRS/downloads",
-            "homepageURL": "https://github.com/CDCgov/MaRS",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "C++",
-                "C",
-                "Roff",
-                "HTML",
-                "Jupyter Notebook",
-                "Perl",
-                "Shell",
-                "Python",
-                "CSS",
-                "Makefile",
-                "JavaScript",
-                "R",
-                "Lua",
-                "M4",
-                "Batchfile",
-                "CMake"
-            ],
-            "name": "MaRS",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": null,
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/MaRS.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/CDCgov/CSV2FASTA.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-06-21",
-                "lastModified": "2019-06-13"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/CDCgov/openshift-fluentd-forwarder/downloads",
-            "homepageURL": "https://github.com/CDCgov/openshift-fluentd-forwarder",
-            "laborHours": 0,
-            "languages": [
-                "Shell",
-                "Dockerfile"
-            ],
-            "name": "openshift-fluentd-forwarder",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/openshift-fluentd-forwarder.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2019-04-17",
+            "lastModified": "2019-08-07"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-05-30",
-                "lastModified": "2017-06-15"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/CDCgov/SDP-CBR-Broker/downloads",
-            "homepageURL": "https://github.com/CDCgov/SDP-CBR-Broker",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "Ruby"
+        "description": "A client-side webapp to scrape data from the standard Epidemiological Interview Record",
+        "downloadURL": "https://api.github.com/repos/CDCgov/Ocra/downloads",
+        "homepageURL": "https://github.com/CDCgov/Ocra",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "HTML",
+            "CSS"
+        ],
+        "name": "Ocra",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "SDP-CBR-Broker",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/SDP-CBR-Broker.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-04-10",
-                "lastModified": "2019-05-09"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/CDCgov/SDP-CBR/downloads",
-            "homepageURL": "https://github.com/CDCgov/SDP-CBR",
-            "laborHours": 0,
-            "languages": [
-                "Java",
-                "ANTLR",
-                "Shell",
-                "Ruby"
-            ],
-            "name": "SDP-CBR",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/SDP-CBR.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "repositoryURL": "git://github.com/CDCgov/Ocra.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2017-04-10",
-                "lastModified": "2018-12-12"
-            },
-            "description": "No description available...",
-            "downloadURL": "https://api.github.com/repos/CDCgov/NLPWorkbench/downloads",
-            "homepageURL": "https://github.com/CDCgov/NLPWorkbench",
-            "laborHours": 0,
-            "languages": [
-                "HTML",
-                "Java",
-                "Python",
-                "PLpgSQL",
-                "JavaScript",
-                "Mako",
-                "CSS",
-                "C++",
-                "Shell",
-                "Perl",
-                "Roff",
-                "PowerShell",
-                "C#",
-                "Pascal",
-                "C",
-                "Makefile",
-                "Batchfile",
-                "Groovy",
-                "Puppet",
-                "TeX",
-                "Smarty",
-                "PLSQL",
-                "XSLT",
-                "SQLPL",
-                "Bluespec",
-                "Dockerfile",
-                "Ruby",
-                "Jupyter Notebook",
-                "ASP"
-            ],
-            "name": "NLPWorkbench",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/NLPWorkbench.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+        "date": {
+            "created": "2019-03-19",
+            "lastModified": "2019-11-19"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2016-09-19",
-                "lastModified": "2019-06-03"
-            },
-            "description": "Repository for the development of the initial SDP vocabulary service. ",
-            "downloadURL": "https://api.github.com/repos/CDCgov/SDP-Vocabulary-Service/downloads",
-            "homepageURL": "https://github.com/CDCgov/SDP-Vocabulary-Service",
-            "laborHours": 0,
-            "languages": [
-                "JavaScript",
-                "Ruby",
-                "CSS",
-                "Gherkin",
-                "HTML",
-                "Shell"
+        "description": "GeneFlow: A Workflow Engine for Bioinformatics and Public Health Analytics",
+        "downloadURL": "https://api.github.com/repos/CDCgov/geneflow/downloads",
+        "homepageURL": "https://github.com/CDCgov/geneflow",
+        "laborHours": 0,
+        "languages": [
+            "Python",
+            "Shell",
+            "Gherkin",
+            "TSQL",
+            "Dockerfile"
+        ],
+        "name": "geneflow",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "name": "SDP-Vocabulary-Service",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/SDP-Vocabulary-Service.git",
-            "status": "Development",
-            "tags": [
-                "github"
-            ],
-            "vcs": "git"
+            "usageType": "openSource"
         },
-        {
-            "contact": {
-                "URL": "https://github.com/CDCgov",
-                "email": "cdcinfo@cdc.gov"
-            },
-            "date": {
-                "created": "2016-05-20",
-                "lastModified": "2019-03-28"
-            },
-            "description": "PoSE: (Pattern of Sequence Evolution) provides visualization and annotation of amino acid substitutions to help determine major patterns during sequence evolution of protein-coding sequences, hypervariable regions, or changes in dN/dS ratios. ",
-            "downloadURL": "https://api.github.com/repos/CDCgov/PoSE/downloads",
-            "homepageURL": "https://github.com/CDCgov/PoSE",
-            "laborHours": 0,
-            "languages": [],
-            "name": "PoSE",
-            "organization": "Centers for Disease Control and Prevention",
-            "permissions": {
-                "licenses": [
-                    {
-                        "URL": "https://api.github.com/licenses/apache-2.0",
-                        "name": "Apache-2.0"
-                    }
-                ],
-                "usageType": "openSource"
-            },
-            "repositoryURL": "git://github.com/CDCgov/PoSE.git",
-            "status": "Development",
-            "tags": [
-                "github"
+        "repositoryURL": "git://github.com/CDCgov/geneflow.git",
+        "status": "Development",
+        "tags": [
+            "github",
+            "bioinformatics",
+            "workflow-engine",
+            "python"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2019-03-18",
+            "lastModified": "2019-05-15"
+        },
+        "description": "A little R package to Launch MicrobeTrace in a Shiny Server",
+        "downloadURL": "https://api.github.com/repos/CDCgov/MicrobeTraceShiny/downloads",
+        "homepageURL": "https://github.com/CDCgov/MicrobeTraceShiny",
+        "laborHours": 0,
+        "languages": [
+            "R"
+        ],
+        "name": "MicrobeTraceShiny",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
             ],
-            "vcs": "git"
-        }
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/MicrobeTraceShiny.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2019-03-07",
+            "lastModified": "2019-03-08"
+        },
+        "description": "Ruby Source-to-Image builder tailored to the needs of the SDP Vocabulary project.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/s2i-ruby-vocab-builder/downloads",
+        "homepageURL": "https://github.com/CDCgov/s2i-ruby-vocab-builder",
+        "laborHours": 0,
+        "languages": [
+            "Shell",
+            "Roff",
+            "Dockerfile",
+            "Makefile",
+            "Ruby"
+        ],
+        "name": "s2i-ruby-vocab-builder",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/s2i-ruby-vocab-builder.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2019-02-11",
+            "lastModified": "2019-02-11"
+        },
+        "description": "A Simple Demonstration of Organizing Bubbles using D3v5",
+        "downloadURL": "https://api.github.com/repos/CDCgov/Bubbles/downloads",
+        "homepageURL": "https://github.com/CDCgov/Bubbles",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "CSS",
+            "R"
+        ],
+        "name": "Bubbles",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "name": "NOASSERTION"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/Bubbles.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2019-01-14",
+            "lastModified": "2019-09-09"
+        },
+        "description": "Uncompromisingly Flexible Phylogenetic Trees in Javascript",
+        "downloadURL": "https://api.github.com/repos/CDCgov/TidyTree/downloads",
+        "homepageURL": "https://github.com/CDCgov/TidyTree",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "HTML"
+        ],
+        "name": "TidyTree",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/TidyTree.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2019-01-03",
+            "lastModified": "2019-08-05"
+        },
+        "description": "Spawn Normally-Distributed Mutant DNA Sequences",
+        "downloadURL": "https://api.github.com/repos/CDCgov/SeqSpawnR/downloads",
+        "homepageURL": "https://github.com/CDCgov/SeqSpawnR",
+        "laborHours": 0,
+        "languages": [
+            "R"
+        ],
+        "name": "SeqSpawnR",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/SeqSpawnR.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-12-14",
+            "lastModified": "2019-05-10"
+        },
+        "description": "A little library to work with Javascript File objects",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fileto/downloads",
+        "homepageURL": "https://github.com/CDCgov/fileto",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript"
+        ],
+        "name": "fileto",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fileto.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-12-07",
+            "lastModified": "2019-01-03"
+        },
+        "description": "A stubbing service for testing against the various endpoints of the FDNS Microservices without running the full microservices in the background.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-stubbing/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-stubbing",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "Makefile",
+            "Dockerfile"
+        ],
+        "name": "fdns-ms-stubbing",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-stubbing.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-12-04",
+            "lastModified": "2019-09-09"
+        },
+        "description": "A Phylogenetics toolkit for Javascript",
+        "downloadURL": "https://api.github.com/repos/CDCgov/patristic/downloads",
+        "homepageURL": "https://github.com/CDCgov/patristic",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "JavaScript",
+            "CSS",
+            "TeX"
+        ],
+        "name": "patristic",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/patristic.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-10-31",
+            "lastModified": "2018-11-13"
+        },
+        "description": "Example UI for an HL7 Combiner Tool",
+        "downloadURL": "https://api.github.com/repos/CDCgov/ex-ui-hl7-combiner/downloads",
+        "homepageURL": "https://github.com/CDCgov/ex-ui-hl7-combiner",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "HTML",
+            "CSS",
+            "Dockerfile",
+            "Makefile",
+            "Shell"
+        ],
+        "name": "ex-ui-hl7-combiner",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/ex-ui-hl7-combiner.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-09-21",
+            "lastModified": "2019-11-11"
+        },
+        "description": "The Visualization Multitool for Molecular Epidemiology and Bioinformatics",
+        "downloadURL": "https://api.github.com/repos/CDCgov/MicrobeTrace/downloads",
+        "homepageURL": "https://github.com/CDCgov/MicrobeTrace",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "JavaScript",
+            "CSS",
+            "Shell",
+            "Dockerfile"
+        ],
+        "name": "MicrobeTrace",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/MicrobeTrace.git",
+        "status": "Development",
+        "tags": [
+            "github",
+            "bioinformatics",
+            "epidemiology",
+            "network-visualization",
+            "hiv",
+            "cdc",
+            "pathogens",
+            "phylogenetics",
+            "phylogenetic-trees",
+            "phylogeny",
+            "phylogenomics",
+            "genomics",
+            "genomics-visualization",
+            "genomic-data-analysis",
+            "sequence-alignment"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-09-06",
+            "lastModified": "2018-12-27"
+        },
+        "description": "This is the repository with the Java Library for Foundation Services Kafka workers.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-kafka-library/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-kafka-library",
+        "laborHours": 0,
+        "languages": [
+            "Java"
+        ],
+        "name": "fdns-kafka-library",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-kafka-library.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-08-09",
+            "lastModified": "2018-12-27"
+        },
+        "description": "This is the repository for the cryptography microservice.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-crypto/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-crypto",
+        "laborHours": 0,
+        "languages": [],
+        "name": "fdns-ms-crypto",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-crypto.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-08-09",
+            "lastModified": "2018-12-27"
+        },
+        "description": "This is the repository that contains the Kafka workers to handle the generation of reports.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-reporting-kafka/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-reporting-kafka",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "Makefile",
+            "Dockerfile",
+            "Shell"
+        ],
+        "name": "fdns-ms-reporting-kafka",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-reporting-kafka.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-08-09",
+            "lastModified": "2019-02-07"
+        },
+        "description": "This is the repository for the reporting microservice.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-reporting/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-reporting",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML",
+            "Makefile",
+            "Dockerfile"
+        ],
+        "name": "fdns-ms-reporting",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-reporting.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-08-09",
+            "lastModified": "2019-02-07"
+        },
+        "description": "This is the repository with the Microsoft Utilities microservice for parsing Microsoft formatted documents.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-msft-utils/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-msft-utils",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML",
+            "Dockerfile",
+            "Makefile"
+        ],
+        "name": "fdns-ms-msft-utils",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-msft-utils.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-06",
+            "lastModified": "2018-08-23"
+        },
+        "description": "This is the repository extending the Springfox Swagger UI package to meet CDC browser requirements.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/springfox-swagger-ui/downloads",
+        "homepageURL": "https://github.com/CDCgov/springfox-swagger-ui",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "JavaScript",
+            "CSS"
+        ],
+        "name": "springfox-swagger-ui",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/springfox-swagger-ui.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-02-07"
+        },
+        "description": "This is the repository with the Business Rules Engine for ingesting and validating JSON files.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-rules/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-rules",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML",
+            "Dockerfile",
+            "Makefile"
+        ],
+        "name": "fdns-ms-rules",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-rules.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-02-13"
+        },
+        "description": "This is the repository with the Combiner service to combine JSON files into a single CSV or XLSX file.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-combiner/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-combiner",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML",
+            "Dockerfile",
+            "Makefile",
+            "Shell"
+        ],
+        "name": "fdns-ms-combiner",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-combiner.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-02-07"
+        },
+        "description": "This is the repository with the CDA utilities service to parse, validate and generate sample CDA data.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-cda-utils/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-cda-utils",
+        "laborHours": 0,
+        "languages": [
+            "FreeMarker",
+            "Java",
+            "HTML",
+            "Dockerfile",
+            "Makefile"
+        ],
+        "name": "fdns-ms-cda-utils",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-cda-utils.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-03-29"
+        },
+        "description": "This is the repository with the HL7 utilities service to parse, validate and generate sample HL7 data.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-hl7-utils/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-hl7-utils",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML",
+            "FreeMarker",
+            "Dockerfile",
+            "Makefile"
+        ],
+        "name": "fdns-ms-hl7-utils",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-hl7-utils.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-02-07"
+        },
+        "description": "This is the repository with the Indexing layer for the Data Lake. This is the navigation layer.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-indexing/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-indexing",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML",
+            "Dockerfile",
+            "Makefile"
+        ],
+        "name": "fdns-ms-indexing",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-indexing.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-02-07"
+        },
+        "description": "This is the repository with the Object layer for the Data Lake. This is the mutable layer.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-object/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-object",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML",
+            "Dockerfile",
+            "Makefile"
+        ],
+        "name": "fdns-ms-object",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-object.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-02-07"
+        },
+        "description": "This is the repository with the Storage layer for the Data Lake. This is the immutable layer.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-storage/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-storage",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "HTML",
+            "Dockerfile",
+            "Makefile"
+        ],
+        "name": "fdns-ms-storage",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-storage.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-02-07"
+        },
+        "description": "This is the repository with the API gateway to connect the other microservices together.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ms-gateway/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ms-gateway",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "Java",
+            "Dockerfile",
+            "Shell",
+            "Makefile"
+        ],
+        "name": "fdns-ms-gateway",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ms-gateway.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2018-12-27"
+        },
+        "description": "This the repository with the Java Library for the Business Rules Engine.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-rules-engine/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-rules-engine",
+        "laborHours": 0,
+        "languages": [
+            "Java"
+        ],
+        "name": "fdns-rules-engine",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-rules-engine.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-02-13"
+        },
+        "description": "This is the repository with the Java SDK for Foundation Services.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-java-sdk/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-java-sdk",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "Makefile"
+        ],
+        "name": "fdns-java-sdk",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-java-sdk.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2018-10-30"
+        },
+        "description": "This is the repository with the JavaScript SDK for Foundation Services.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-js-sdk/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-js-sdk",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript"
+        ],
+        "name": "fdns-js-sdk",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-js-sdk.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-04-03",
+            "lastModified": "2019-11-07"
+        },
+        "description": "This is the repository with the front-end library built in React.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/fdns-ui-react/downloads",
+        "homepageURL": "https://github.com/CDCgov/fdns-ui-react",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "CSS",
+            "HTML"
+        ],
+        "name": "fdns-ui-react",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/fdns-ui-react.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-03-19",
+            "lastModified": "2019-05-15"
+        },
+        "description": "Pick a county, see its neighbors",
+        "downloadURL": "https://api.github.com/repos/CDCgov/Proximate/downloads",
+        "homepageURL": "https://github.com/CDCgov/Proximate",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "HTML",
+            "CSS"
+        ],
+        "name": "Proximate",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/Proximate.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-02-07",
+            "lastModified": "2019-08-22"
+        },
+        "description": "Tamura-Nei '93 Computation in Javascript",
+        "downloadURL": "https://api.github.com/repos/CDCgov/tn93.js/downloads",
+        "homepageURL": "https://github.com/CDCgov/tn93.js",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "HTML",
+            "CSS"
+        ],
+        "name": "tn93.js",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/tn93.js.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2018-02-07",
+            "lastModified": "2019-08-06"
+        },
+        "description": "A lightweight visualization for genetic sequence alignments",
+        "downloadURL": "https://api.github.com/repos/CDCgov/AlignmentViewer/downloads",
+        "homepageURL": "https://github.com/CDCgov/AlignmentViewer",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "HTML"
+        ],
+        "name": "AlignmentViewer",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/AlignmentViewer.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2017-12-25",
+            "lastModified": "2019-01-18"
+        },
+        "description": "An application to assist Utah CDC's Newborn Screening Program",
+        "downloadURL": "https://api.github.com/repos/CDCgov/artemis/downloads",
+        "homepageURL": "https://github.com/CDCgov/artemis",
+        "laborHours": 0,
+        "languages": [
+            "Ruby",
+            "HTML",
+            "CSS",
+            "JavaScript",
+            "Dockerfile"
+        ],
+        "name": "artemis",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "name": "NOASSERTION"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/artemis.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2017-12-06",
+            "lastModified": "2019-07-08"
+        },
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/CDCgov/MaRS/downloads",
+        "homepageURL": "https://github.com/CDCgov/MaRS",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "C++",
+            "C",
+            "Roff",
+            "HTML",
+            "Jupyter Notebook",
+            "Perl",
+            "Shell",
+            "Python",
+            "CSS",
+            "Makefile",
+            "JavaScript",
+            "R",
+            "Lua",
+            "M4",
+            "Batchfile",
+            "CMake"
+        ],
+        "name": "MaRS",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": null,
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/MaRS.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2017-06-21",
+            "lastModified": "2019-07-17"
+        },
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/CDCgov/openshift-fluentd-forwarder/downloads",
+        "homepageURL": "https://github.com/CDCgov/openshift-fluentd-forwarder",
+        "laborHours": 0,
+        "languages": [
+            "Shell",
+            "Dockerfile"
+        ],
+        "name": "openshift-fluentd-forwarder",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/openshift-fluentd-forwarder.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2017-05-30",
+            "lastModified": "2017-06-15"
+        },
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/CDCgov/SDP-CBR-Broker/downloads",
+        "homepageURL": "https://github.com/CDCgov/SDP-CBR-Broker",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "Ruby"
+        ],
+        "name": "SDP-CBR-Broker",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/SDP-CBR-Broker.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2017-04-10",
+            "lastModified": "2019-05-09"
+        },
+        "description": "No description available...",
+        "downloadURL": "https://api.github.com/repos/CDCgov/SDP-CBR/downloads",
+        "homepageURL": "https://github.com/CDCgov/SDP-CBR",
+        "laborHours": 0,
+        "languages": [
+            "Java",
+            "ANTLR",
+            "Shell",
+            "Ruby"
+        ],
+        "name": "SDP-CBR",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/SDP-CBR.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2017-04-10",
+            "lastModified": "2019-10-28"
+        },
+        "description": "Natural Language processing for Pathology reports on cancer histology, laterality, side, and behavior.",
+        "downloadURL": "https://api.github.com/repos/CDCgov/NLPWorkbench/downloads",
+        "homepageURL": "https://github.com/CDCgov/NLPWorkbench",
+        "laborHours": 0,
+        "languages": [
+            "HTML",
+            "Java",
+            "Python",
+            "PLpgSQL",
+            "JavaScript",
+            "Mako",
+            "CSS",
+            "C++",
+            "Shell",
+            "Perl",
+            "Roff",
+            "PowerShell",
+            "C#",
+            "Pascal",
+            "C",
+            "Makefile",
+            "Batchfile",
+            "Groovy",
+            "Puppet",
+            "TeX",
+            "Smarty",
+            "PLSQL",
+            "XSLT",
+            "SQLPL",
+            "Bluespec",
+            "Dockerfile",
+            "Ruby",
+            "Jupyter Notebook",
+            "ASP"
+        ],
+        "name": "NLPWorkbench",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/NLPWorkbench.git",
+        "status": "Development",
+        "tags": [
+            "github",
+            "usg-artificial-intelligence",
+            "usg-natural-language-processing"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2016-09-19",
+            "lastModified": "2019-08-26"
+        },
+        "description": "Repository for the development of the initial SDP vocabulary service. ",
+        "downloadURL": "https://api.github.com/repos/CDCgov/SDP-Vocabulary-Service/downloads",
+        "homepageURL": "https://github.com/CDCgov/SDP-Vocabulary-Service",
+        "laborHours": 0,
+        "languages": [
+            "JavaScript",
+            "Ruby",
+            "CSS",
+            "Gherkin",
+            "HTML",
+            "Shell"
+        ],
+        "name": "SDP-Vocabulary-Service",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/SDP-Vocabulary-Service.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    },
+    {
+        "contact": {
+            "URL": "https://github.com/CDCgov",
+            "email": "cdcinfo@cdc.gov"
+        },
+        "date": {
+            "created": "2016-05-20",
+            "lastModified": "2019-03-28"
+        },
+        "description": "PoSE: (Pattern of Sequence Evolution) provides visualization and annotation of amino acid substitutions to help determine major patterns during sequence evolution of protein-coding sequences, hypervariable regions, or changes in dN/dS ratios. ",
+        "downloadURL": "https://api.github.com/repos/CDCgov/PoSE/downloads",
+        "homepageURL": "https://github.com/CDCgov/PoSE",
+        "laborHours": 0,
+        "languages": [],
+        "name": "PoSE",
+        "organization": "Centers for Disease Control and Prevention",
+        "permissions": {
+            "licenses": [
+                {
+                    "URL": "https://api.github.com/licenses/apache-2.0",
+                    "name": "Apache-2.0"
+                }
+            ],
+            "usageType": "openSource"
+        },
+        "repositoryURL": "git://github.com/CDCgov/PoSE.git",
+        "status": "Development",
+        "tags": [
+            "github"
+        ],
+        "vcs": "git"
+    }
 	]
 }


### PR DESCRIPTION
Here is the latest quarterly update of CDC projects.

I wasn't able to determine what whitespace or indention pattern was easiest for y'all to follow, so you might want to [ignore whitespace](https://github.com/CDCgov/Source-Code-Inventory/commit/9e8c1c7c897796ebc99d308ab67ba2e82633d0a8?w=1) when diffing to see the our updates.

There are four new projects as well as a number of updated dates, descriptions, and tags for projects that have changed since the last PR. This also includes the first project we have that uses the [OMB AI tagging guidelines that GSA put out](https://code.gov/assets/data/ai_inventory-guidance.pdf).